### PR TITLE
Change package path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,56 @@
-# Created by https://www.toptal.com/developers/gitignore/api/go,visualstudiocode,visualstudio,windows,linux,macos
-# Edit at https://www.toptal.com/developers/gitignore?templates=go,visualstudiocode,visualstudio,windows,linux,macos
+# Created by https://www.toptal.com/developers/gitignore/api/go,visualstudio,windows,linux,macos,vim,emacs,jetbrains+all
+# Edit at https://www.toptal.com/developers/gitignore?templates=go,visualstudio,windows,linux,macos,vim,emacs,jetbrains+all
+
+### Emacs ###
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+dist/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+
+# directory configuration
+.dir-locals.el
+
+# network security
+/network-security.data
+
 
 ### Go ###
 # If you prefer the allow list template instead of the deny list, see community template:
@@ -24,8 +75,95 @@
 # Go workspace file
 go.work
 
+### JetBrains+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### JetBrains+all Patch ###
+# Ignore everything but code style settings and run configurations
+# that are supposed to be shared within teams.
+
+.idea/*
+
+!.idea/codeStyles
+!.idea/runConfigurations
+
 ### Linux ###
-*~
 
 # temporary files which can be created if a process still has a handle open of a deleted file
 .fuse_hidden*
@@ -72,24 +210,25 @@ Temporary Items
 # iCloud generated files
 *.icloud
 
-### VisualStudioCode ###
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
-!.vscode/*.code-snippets
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
 
-# Local History for Visual Studio Code
-.history/
+# Session
+Session.vim
+Sessionx.vim
 
-# Built Visual Studio Code Extensions
-*.vsix
-
-### VisualStudioCode Patch ###
-# Ignore all local history of files
-.history
-.ionide
+# Temporary
+.netrwhist
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
 
 ### Windows ###
 # Windows thumbnail cache files
@@ -494,9 +633,15 @@ MigrationBackup/
 FodyWeavers.xsd
 
 # VS Code files for those working on multiple tools
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
 *.code-workspace
 
 # Local History for Visual Studio Code
+.history/
 
 # Windows Installer files from build outputs
 
@@ -506,4 +651,4 @@ FodyWeavers.xsd
 ### VisualStudio Patch ###
 # Additional files built by Visual Studio
 
-# End of https://www.toptal.com/developers/gitignore/api/go,visualstudiocode,visualstudio,windows,linux,macos
+# End of https://www.toptal.com/developers/gitignore/api/go,visualstudio,windows,linux,macos,vim,emacs,jetbrains+all

--- a/examples/example.go
+++ b/examples/example.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 	"time"
 
-	"conalog.com/iotc4i"
+	"github.com/conalog/iotc4i"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module conalog.com/iotc4i
+module github.com/conalog/iotc4i
 
 go 1.22.1
 


### PR DESCRIPTION
Cannot get package using github path

```
$ go get "github.com/conalog/iotc4i"
go: github.com/conalog/iotc4i@v0.1.0 requires go >= 1.22.1; switching to go1.22.7
go: github.com/conalog/iotc4i@upgrade (v0.1.0) requires github.com/conalog/iotc4i@v0.1.0: parsing go.mod:
	module declares its path as: conalog.com/iotc4i
	        but was required as: github.com/conalog/iotc4i
```

Cannot get package using conalog.com path also

```
$  go get "conalog.com/iotc4i"
go: unrecognized import path "conalog.com/iotc4i": reading https://conalog.com/iotc4i?go-get=1: 404 Not Found
```